### PR TITLE
lcy分支第一次提交

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -47,6 +47,8 @@ EMBEDDING_MODEL=BAAI/bge-small-zh-v1.5
 EMBEDDING_DEVICE=cpu
 RAG_SCORE_THRESHOLD=0.4
 RAG_TOP_K=3
+RAG_ANCHOR_TOP_K=8
+ANCHOR_QUANT_EPSILON=0.02
 
 # ------------------------------------------------------------
 # 前端本地开发（Vite；生产 Docker 前端走同源 /api，一般无需改）

--- a/backend/app/api/knowledge.py
+++ b/backend/app/api/knowledge.py
@@ -19,7 +19,7 @@ from app.schemas.knowledge import (
 )
 from app.middleware.auth import get_current_user, require_operator, CurrentUser
 from app.utils.response import success
-from app.rag.retriever import add_entry, delete_entry
+from app.rag.retriever import ingest_kb_entry, prune_anchor_if_unused
 
 router = APIRouter(prefix="/api/knowledge", tags=["知识库"])
 
@@ -71,11 +71,12 @@ def quick_prompts(
 
 @router.get("", summary="查询知识库列表")
 def list_entries(
-    category:  Optional[str] = Query(None),
-    source:    Optional[str] = Query(None),
-    keyword:   Optional[str] = Query(None),
-    page:      int = Query(1, ge=1),
-    page_size: int = Query(20, ge=1, le=100),
+    category:    Optional[str] = Query(None),
+    source:      Optional[str] = Query(None),
+    keyword:     Optional[str] = Query(None),
+    doc_id:      Optional[str] = Query(None),
+    page:        int = Query(1, ge=1),
+    page_size:   int = Query(20, ge=1, le=100),
     db: Session = Depends(get_db),
     current_user: CurrentUser = Depends(require_operator),
 ):
@@ -84,6 +85,8 @@ def list_entries(
         q = q.filter(KBEntry.category == category)
     if source:
         q = q.filter(KBEntry.source == source)
+    if doc_id:
+        q = q.filter(KBEntry.doc_id == doc_id)
     if keyword:
         like = f"%{keyword}%"
         q = q.filter(or_(
@@ -101,6 +104,29 @@ def list_entries(
     ).model_dump())
 
 
+@router.delete("/by-doc", summary="按文档标识或页码批量删除条目")
+def delete_entries_by_doc(
+    doc_id: str = Query(..., min_length=1, max_length=128),
+    page_index: Optional[int] = Query(None, ge=1),
+    db: Session = Depends(get_db),
+    current_user: CurrentUser = Depends(require_operator),
+):
+    q = db.query(KBEntry).filter(KBEntry.doc_id == doc_id)
+    if page_index is not None:
+        q = q.filter(KBEntry.page_index == page_index)
+    rows = q.all()
+    if not rows:
+        raise HTTPException(status_code=404, detail="未找到匹配的条目")
+    anchor_ids = list({r.anchor_id for r in rows if r.anchor_id})
+    for r in rows:
+        db.delete(r)
+    db.commit()
+    for aid in anchor_ids:
+        prune_anchor_if_unused(db, aid)
+    db.commit()
+    return success(message=f"已删除 {len(rows)} 条")
+
+
 @router.post("", summary="新建知识库条目")
 def create_entry(
     req: KBEntryCreate,
@@ -113,10 +139,20 @@ def create_entry(
     db.refresh(entry)
     emb_warning = None
     try:
-        add_entry(entry.id, entry.question, entry.solution, entry.category)
+        ingest_kb_entry(
+            db,
+            entry.id,
+            entry.question,
+            entry.solution,
+            entry.category,
+            entry.doc_id,
+            entry.page_index,
+        )
+        db.commit()
+        db.refresh(entry)
     except Exception as e:
-        logger.warning(f"pgvector sync failed for new entry {entry.id}: {e}")
-        emb_warning = "条目已保存，但向量索引生成失败，该条目暂时无法被 AI 检索"
+        logger.warning(f"anchor/embedding sync failed for new entry {entry.id}: {e}")
+        emb_warning = "条目已保存，但向量同步失败，该条目暂时无法被 AI 检索"
     return success(data=KBEntryResponse.model_validate(entry).model_dump(), message=emb_warning or "条目已创建")
 
 
@@ -130,6 +166,7 @@ def update_entry(
     entry = db.query(KBEntry).filter(KBEntry.id == entry_id).first()
     if not entry:
         raise HTTPException(status_code=404, detail="条目不存在")
+    old_anchor = entry.anchor_id
     for field, value in req.model_dump(exclude_unset=True).items():
         if value is not None:
             setattr(entry, field, value)
@@ -137,15 +174,27 @@ def update_entry(
     db.refresh(entry)
     emb_warning = None
     try:
-        add_entry(entry.id, entry.question, entry.solution, entry.category)
+        ingest_kb_entry(
+            db,
+            entry.id,
+            entry.question,
+            entry.solution,
+            entry.category,
+            entry.doc_id,
+            entry.page_index,
+        )
+        db.commit()
+        db.refresh(entry)
+        prune_anchor_if_unused(db, old_anchor)
+        db.commit()
     except Exception as e:
-        logger.warning(f"pgvector sync failed for update entry {entry.id}: {e}")
-        emb_warning = "条目已保存，但向量索引生成失败，该条目暂时无法被 AI 检索"
+        logger.warning(f"anchor/embedding sync failed for update entry {entry.id}: {e}")
+        emb_warning = "条目已保存，但向量同步失败，该条目暂时无法被 AI 检索"
     return success(data=KBEntryResponse.model_validate(entry).model_dump(), message=emb_warning or "条目已更新")
 
 
 @router.delete("/{entry_id}", summary="删除知识库条目")
-def delete_entry(
+def remove_kb_entry(
     entry_id: int,
     db: Session = Depends(get_db),
     current_user: CurrentUser = Depends(require_operator),
@@ -153,10 +202,9 @@ def delete_entry(
     entry = db.query(KBEntry).filter(KBEntry.id == entry_id).first()
     if not entry:
         raise HTTPException(status_code=404, detail="条目不存在")
+    aid = entry.anchor_id
     db.delete(entry)
     db.commit()
-    try:
-        delete_entry(entry_id)
-    except Exception as e:
-        logger.warning(f"pgvector delete failed for entry {entry_id}: {e}")
+    prune_anchor_if_unused(db, aid)
+    db.commit()
     return success(message="条目已删除")

--- a/backend/app/api/ticket.py
+++ b/backend/app/api/ticket.py
@@ -1,7 +1,10 @@
+import logging
 from fastapi import APIRouter, Depends, Query, HTTPException
 from sqlalchemy.orm import Session
 from typing import Optional
 from datetime import datetime
+
+logger = logging.getLogger(__name__)
 
 from app.database import get_db
 from app.models.ticket import Ticket, TicketLog
@@ -12,6 +15,7 @@ from app.schemas.ticket import (
 )
 from app.middleware.auth import require_operator, CurrentUser
 from app.utils.response import success
+from app.rag.retriever import ingest_kb_entry
 
 router = APIRouter(prefix="/api/tickets", tags=["工单管理"])
 
@@ -200,8 +204,23 @@ def resolve_ticket(ticket_id: int, req: TicketResolve, db: Session = Depends(get
             solution=req.solution,
             source="ticket_writeback",
             match_score=0.8,
+            doc_id=f"ticket-{ticket.ticket_no}",
+            page_index=1,
         )
         db.add(kb_entry)
+        db.flush()
+        try:
+            ingest_kb_entry(
+                db,
+                kb_entry.id,
+                kb_entry.question,
+                kb_entry.solution,
+                kb_entry.category,
+                kb_entry.doc_id,
+                kb_entry.page_index,
+            )
+        except Exception as embed_err:
+            logger.warning(f"工单回写知识库向量同步失败: {embed_err}")
         add_log(db, ticket.id, action="writeback",
                 operator_id=current_user.id,
                 operator_name=current_user.username,

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -25,6 +25,8 @@ class Settings(BaseSettings):
     EMBEDDING_DEVICE: str = "cpu"
     RAG_SCORE_THRESHOLD: float = 0.4
     RAG_TOP_K: int = 3
+    RAG_ANCHOR_TOP_K: int = 8
+    ANCHOR_QUANT_EPSILON: float = 0.02
 
     class Config:
         env_file = str(_ENV_FILE)

--- a/backend/app/rag/faq_loader.py
+++ b/backend/app/rag/faq_loader.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from sqlalchemy.orm import Session
 
 from app.models.knowledge import KBEntry
-from app.rag.retriever import add_entry
+from app.rag.retriever import ingest_kb_entry
 
 logger = logging.getLogger(__name__)
 
@@ -43,11 +43,11 @@ def load_faq_if_empty(db: Session):
 
     db.flush()  # Assign IDs without committing
 
-    # Write embeddings to PostgreSQL
+    FAQ_DOC_ID = "OpsWarden_FAQ"
     embed_ok = 0
-    for obj in db_entries:
+    for idx, obj in enumerate(db_entries, start=1):
         try:
-            add_entry(obj.id, obj.question, obj.solution, obj.category)
+            ingest_kb_entry(db, obj.id, obj.question, obj.solution, obj.category, FAQ_DOC_ID, idx)
             embed_ok += 1
         except Exception as e:
             logger.warning(f"Embedding sync failed for entry {obj.id}: {e}")

--- a/backend/app/rag/quantizer.py
+++ b/backend/app/rag/quantizer.py
@@ -1,0 +1,15 @@
+"""向量量化：网格吸附 anchor_vec = round(v / ε) * ε。"""
+import hashlib
+
+import numpy as np
+
+
+def quantize_vector(vec: list[float], epsilon: float) -> np.ndarray:
+    v = np.asarray(vec, dtype=np.float64)
+    return np.round(v / epsilon) * epsilon
+
+
+def quant_key_from_vector(quantized: np.ndarray) -> str:
+    """稳定锚点去重用 SHA256（量化后 float32 字节）。"""
+    q = np.asarray(quantized, dtype=np.float32)
+    return hashlib.sha256(q.tobytes()).hexdigest()

--- a/backend/app/rag/retriever.py
+++ b/backend/app/rag/retriever.py
@@ -1,68 +1,136 @@
 import logging
-from sqlalchemy import select, update
-from pgvector.sqlalchemy import Vector
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+from sqlalchemy import update as sql_update
+import numpy as np
+
 from app.config import get_settings
 from app.database import SessionLocal
-from app.models.knowledge import KBEntry
+from app.models.knowledge import KBAnchor, KBEntry
 from app.rag.embedder import embed_query, embed_document
+from app.rag.quantizer import quantize_vector, quant_key_from_vector
 
 logger = logging.getLogger(__name__)
 
 
-def search(query: str, top_k: int = None, threshold: float = None) -> list[dict]:
+def _get_or_create_anchor(db: Session, quantized_list: list[float]) -> int:
+    """quantized_list 与 anchor_vec 存储一致顺序。"""
+    q_arr = np.asarray(quantized_list, dtype=np.float64)
+    qk = quant_key_from_vector(q_arr)
+    row = db.query(KBAnchor).filter(KBAnchor.quant_key == qk).first()
+    if row:
+        return int(row.id)
+    anchor = KBAnchor(
+        quant_key=qk,
+        anchor_vec=quantized_list,
+    )
+    db.add(anchor)
+    db.flush()
+    return int(anchor.id)
+
+
+def ingest_kb_entry(
+    db: Session,
+    entry_id: int,
+    question: str,
+    solution: str,
+    category: str,
+    doc_id: str,
+    page_index: int,
+) -> None:
+    """写入切片向量：量化锚点 upsert + 条目 embedding / anchor_id / doc 元数据。"""
+    settings = get_settings()
+    eps = settings.ANCHOR_QUANT_EPSILON
+    raw = embed_document(f"{question} {solution}")
+    qv = quantize_vector(raw, eps)
+    q_list = qv.astype(float).tolist()
+    aid = _get_or_create_anchor(db, q_list)
+    db.execute(
+        sql_update(KBEntry)
+        .where(KBEntry.id == entry_id)
+        .values(
+            anchor_id=aid,
+            embedding=raw,
+            doc_id=doc_id,
+            page_index=page_index,
+        )
+    )
+
+
+def prune_anchor_if_unused(db: Session, anchor_id: int | None) -> None:
+    if anchor_id is None:
+        return
+    n = db.query(KBEntry).filter(KBEntry.anchor_id == anchor_id).count()
+    if n == 0:
+        db.query(KBAnchor).filter(KBAnchor.id == anchor_id).delete()
+        db.flush()
+
+
+def search(query: str, top_k: int | None = None, threshold: float | None = None) -> list[dict]:
     settings = get_settings()
     if top_k is None:
         top_k = settings.RAG_TOP_K
     if threshold is None:
         threshold = settings.RAG_SCORE_THRESHOLD
+    anchor_k = settings.RAG_ANCHOR_TOP_K
 
     try:
-        vec = embed_query(query)
+        qvec = embed_query(query)
+        q = np.asarray(qvec, dtype=np.float64)
+        qn = float(np.linalg.norm(q)) + 1e-12
+
         with SessionLocal() as db:
-            total = db.query(KBEntry).filter(KBEntry.embedding.isnot(None)).count()
-            if total == 0:
+            acnt = db.query(KBAnchor).count()
+            if acnt == 0:
                 return []
 
-            # cosine_distance returns 0=identical, 2=opposite; score = 1 - distance
-            distance_expr = KBEntry.embedding.cosine_distance(vec)
-            rows = db.execute(
-                select(KBEntry, (1 - distance_expr).label("score"))
-                .where(KBEntry.embedding.isnot(None))
+            distance_expr = KBAnchor.anchor_vec.cosine_distance(qvec)
+            anchor_rows = db.execute(
+                select(KBAnchor, (1 - distance_expr).label("ascore"))
                 .order_by(distance_expr)
-                .limit(top_k)
+                .limit(anchor_k)
             ).all()
 
-        return [
-            {
-                "id": row.KBEntry.id,
-                "question": row.KBEntry.question,
-                "solution": row.KBEntry.solution,
-                "category": row.KBEntry.category,
-                "score": round(float(row.score), 4),
-            }
-            for row in rows
-            if float(row.score) >= threshold
-        ]
-    except Exception as e:
-        logger.warning(f"pgvector search error: {e}")
+            anchor_ids = [int(r.KBAnchor.id) for r in anchor_rows]
+            if not anchor_ids:
+                return []
+
+            entries = (
+                db.query(KBEntry)
+                .filter(
+                    KBEntry.anchor_id.in_(anchor_ids),
+                    KBEntry.embedding.isnot(None),
+                )
+                .all()
+            )
+
+        scored: list[tuple[KBEntry, float]] = []
+        for e in entries:
+            ev = np.asarray(e.embedding, dtype=np.float64)
+            en = float(np.linalg.norm(ev)) + 1e-12
+            score = float(np.dot(q, ev) / (qn * en))
+            if score >= threshold:
+                scored.append((e, score))
+
+        scored.sort(key=lambda x: -x[1])
+        out = []
+        for e, sc in scored[:top_k]:
+            out.append({
+                "id": e.id,
+                "question": e.question,
+                "solution": e.solution,
+                "category": e.category,
+                "score": round(sc, 4),
+            })
+        return out
+    except Exception as ex:
+        logger.warning(f"RAG search error: {ex}")
         return []
 
 
-def add_entry(entry_id: int, question: str, solution: str, category: str):
-    vec = embed_document(f"{question} {solution}")
-    with SessionLocal() as db:
-        db.execute(
-            update(KBEntry).where(KBEntry.id == entry_id).values(embedding=vec)
-        )
-        db.commit()
-
-
-def delete_entry(entry_id: int):
-    with SessionLocal() as db:
-        db.execute(
-            update(KBEntry).where(KBEntry.id == entry_id).values(embedding=None)
-        )
-        db.commit()
+def delete_entry_embed_only(entry_id: int):
+    """兼容旧名：已由行删除代替；保留空实现避免误调用。"""
+    logger.debug("delete_entry_embed_only noop for entry_id=%s", entry_id)
 
 
 def collection_count() -> int:

--- a/backend/app/schemas/knowledge.py
+++ b/backend/app/schemas/knowledge.py
@@ -9,6 +9,8 @@ class KBEntryCreate(BaseModel):
     solution:    str          = Field(..., min_length=1)
     tags:        Optional[str] = Field(None, max_length=256)
     match_score: Optional[float] = Field(0.8, ge=0.0, le=1.0)
+    doc_id:      str          = Field(default="manual", min_length=1, max_length=128)
+    page_index:  int          = Field(default=1, ge=1)
 
 
 class KBEntryUpdate(BaseModel):
@@ -17,6 +19,8 @@ class KBEntryUpdate(BaseModel):
     solution:    Optional[str]   = None
     tags:        Optional[str]   = Field(None, max_length=256)
     match_score: Optional[float] = Field(None, ge=0.0, le=1.0)
+    doc_id:      Optional[str]   = Field(None, max_length=128)
+    page_index:  Optional[int]   = Field(None, ge=1)
 
 
 class KBEntryResponse(BaseModel):
@@ -27,6 +31,9 @@ class KBEntryResponse(BaseModel):
     tags:        Optional[str] = None
     source:      str
     match_score: float
+    anchor_id:   Optional[int] = None
+    doc_id:      str
+    page_index:  int
     created_at:  datetime
     updated_at:  datetime
 

--- a/init.sql
+++ b/init.sql
@@ -98,7 +98,20 @@ CREATE TABLE IF NOT EXISTS ticket_logs (
 CREATE INDEX IF NOT EXISTS idx_ticket_logs_ticket_id ON ticket_logs (ticket_id);
 
 -- ==========================================
--- 知识库条目表
+-- 知识库：量化锚点（L1，仅此表建向量 ANN 索引）
+-- ==========================================
+CREATE TABLE IF NOT EXISTS kb_anchors (
+    id          BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    quant_key   VARCHAR(64)  NOT NULL UNIQUE,
+    anchor_vec  vector(512)  NOT NULL,
+    created_at  TIMESTAMPTZ  NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_kb_anchors_vec ON kb_anchors
+    USING ivfflat (anchor_vec vector_cosine_ops) WITH (lists = 50);
+
+-- ==========================================
+-- 知识库条目（L2：页级索引，embedding 仅用于候选集内精排，无向量索引）
 -- ==========================================
 CREATE TABLE IF NOT EXISTS kb_entries (
     id          BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
@@ -108,6 +121,9 @@ CREATE TABLE IF NOT EXISTS kb_entries (
     tags        VARCHAR(256),
     source      kb_source    NOT NULL DEFAULT 'manual',
     match_score FLOAT        NOT NULL DEFAULT 0.8,
+    anchor_id   BIGINT       REFERENCES kb_anchors(id) ON DELETE RESTRICT,
+    doc_id      VARCHAR(128) NOT NULL DEFAULT 'legacy',
+    page_index  INTEGER      NOT NULL DEFAULT 1,
     embedding   vector(512),
     created_at  TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
     updated_at  TIMESTAMPTZ  NOT NULL DEFAULT NOW()
@@ -115,9 +131,9 @@ CREATE TABLE IF NOT EXISTS kb_entries (
 
 CREATE INDEX IF NOT EXISTS idx_kb_category ON kb_entries (category);
 CREATE INDEX IF NOT EXISTS idx_kb_source   ON kb_entries (source);
--- IVFFlat index for fast approximate nearest-neighbor search
-CREATE INDEX IF NOT EXISTS idx_kb_embedding ON kb_entries
-    USING ivfflat (embedding vector_cosine_ops) WITH (lists = 100);
+CREATE INDEX IF NOT EXISTS idx_kb_anchor_id ON kb_entries (anchor_id);
+CREATE INDEX IF NOT EXISTS idx_kb_doc_id ON kb_entries (doc_id);
+CREATE INDEX IF NOT EXISTS idx_kb_doc_page ON kb_entries (doc_id, page_index);
 
 -- ==========================================
 -- 默认管理员账号（密码: admin123）

--- a/scripts/migrate_kb_anchors.sql
+++ b/scripts/migrate_kb_anchors.sql
@@ -1,0 +1,30 @@
+-- 将已有 kb_entries（单表 IVFFlat）迁移为 kb_anchors + 改造 kb_entries。
+-- 在维护窗口执行；执行前备份数据库。
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS kb_anchors (
+    id          BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    quant_key   VARCHAR(64)  NOT NULL UNIQUE,
+    anchor_vec  vector(512)  NOT NULL,
+    created_at  TIMESTAMPTZ  NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_kb_anchors_vec ON kb_anchors
+    USING ivfflat (anchor_vec vector_cosine_ops) WITH (lists = 50);
+
+DROP INDEX IF EXISTS idx_kb_embedding;
+
+ALTER TABLE kb_entries ADD COLUMN IF NOT EXISTS anchor_id BIGINT REFERENCES kb_anchors(id) ON DELETE RESTRICT;
+ALTER TABLE kb_entries ADD COLUMN IF NOT EXISTS doc_id VARCHAR(128) NOT NULL DEFAULT 'legacy';
+ALTER TABLE kb_entries ADD COLUMN IF NOT EXISTS page_index INTEGER NOT NULL DEFAULT 1;
+
+CREATE INDEX IF NOT EXISTS idx_kb_anchor_id ON kb_entries (anchor_id);
+CREATE INDEX IF NOT EXISTS idx_kb_doc_id ON kb_entries (doc_id);
+CREATE INDEX IF NOT EXISTS idx_kb_doc_page ON kb_entries (doc_id, page_index);
+
+-- 存量 embedding：每条暂挂独立锚点占位（上线后可通过后台批量重算量化锚点）
+-- 此处仅保证结构可用；完整回填需运行应用内 ingest 或离线脚本。
+UPDATE kb_entries SET doc_id = COALESCE(NULLIF(TRIM(doc_id), ''), 'legacy') WHERE doc_id IS NULL;
+
+COMMIT;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> High risk because it changes the RAG retrieval algorithm and introduces a new `kb_anchors` table with migrations/index changes, which can affect search relevance, performance, and production data integrity.
> 
> **Overview**
> Refactors knowledge-base RAG from single-table ANN search over `kb_entries.embedding` to a **two-level anchor design**: new `kb_anchors` table stores quantized vectors with the only IVFFlat index, while `kb_entries` keeps per-entry embeddings for reranking within anchor candidates.
> 
> Adds vector quantization (`ANCHOR_QUANT_EPSILON`) and new search tuning (`RAG_ANCHOR_TOP_K`), plus new ingestion flow `ingest_kb_entry()` that upserts anchors and updates entries with `anchor_id`, `doc_id`, and `page_index`; unused anchors are pruned on entry update/delete and a new `DELETE /api/knowledge/by-doc` supports batch deletion by `doc_id`/page.
> 
> Updates ticket writeback and FAQ loading to use the new ingestion path (including generating `doc_id`/`page_index`), and updates schema/init SQL plus a `scripts/migrate_kb_anchors.sql` migration to create anchors, drop the old embedding index, and add new columns/indexes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c98fe29b2a12f36674542636064853d59a172a61. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->